### PR TITLE
Do not check session

### DIFF
--- a/app/controllers/check_controller.rb
+++ b/app/controllers/check_controller.rb
@@ -1,7 +1,7 @@
 class CheckController < ApplicationController
   # Skip the default filters from ApplicationController.
   # They are not needed here as we don't do anything fancy.
-  skip_before_filter :user_setup, :check_if_login_required, :set_localization
+  skip_before_filter :user_setup, :check_if_login_required, :set_localization, :check_session_lifetime
 
   # perform a check select on the database and return with HTTP 200 if it
   # succeeded or HTTP 500 if it failed for some reason


### PR DESCRIPTION
When you are logged out because you're session expired you get redirected to the login page with a back url. But since the before filter `check_if_login_required` is disabled we do not have to login and get redirected to the check page. 

This led to the following log:

``` bash
Started GET "/check" for 10.1.1.1 at 2015-06-12 14:02:01 +0000
Processing by WelcomeController#index as HTML
...
Processing by CheckController#index as HTML
...
Redirected to http://10.1.1.2/login?back_url=http%3A%2F%2F10.1.1.2%2F
Filter chain halted as :check_session_lifetime rendered or redirected
Completed 302 Found in 588.4ms (ActiveRecord: 16.4ms)
   (0.2ms)  SELECT 1;
  Rendered text template (0.0ms)
Completed 200 OK in 410.2ms (Views: 7.0ms | ActiveRecord: 19.9ms)
```

But a monitoring tool, e.g. nagius somehow just sees the 302. Related to https://community.openproject.org/work_packages/20359
